### PR TITLE
Add ROLE_MATCH_LEARNER_RECORD_RW to Frontend

### DIFF
--- a/integration_tests/e2e/errors/lrsDownJourney.cy.ts
+++ b/integration_tests/e2e/errors/lrsDownJourney.cy.ts
@@ -14,7 +14,7 @@ context('LRS Down Journey', () => {
     cy.task('stubLearnerRecordsNoMatchForAll')
     cy.task('stubLearnerRecordsEventsExactMatch')
     cy.task('stubLearnerRecordsLearnersLRSDownError')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'Someone Withaname', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('should be presented with the 500 error page if LRS is unavailable', () => {

--- a/integration_tests/e2e/errors/prisonApiDownJourney.cy.ts
+++ b/integration_tests/e2e/errors/prisonApiDownJourney.cy.ts
@@ -12,7 +12,7 @@ context('Prison Api Down Journey', () => {
     cy.task('stubPrisonApiPrisonerImage500Response')
     cy.task('stubPrisonerApiGetPrisonerById', chosenPrisoner.prisonerNumber)
     cy.task('stubLearnerRecordsNoMatchForAll')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'Someone Withaname', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('should be presented with the 500 error page if the Prison Api returns an error', () => {

--- a/integration_tests/e2e/errors/prisonerSearchApiDownJourney.cy.ts
+++ b/integration_tests/e2e/errors/prisonerSearchApiDownJourney.cy.ts
@@ -6,7 +6,7 @@ context('Prisoner Search Api Down Journey', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubPrisonerApiPrisonerSearch500Error')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'Someone Withaname', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('should be presented with the 500 error page if the prisoner search API returns an error', () => {

--- a/integration_tests/e2e/findAPrisonerJourney.cy.ts
+++ b/integration_tests/e2e/findAPrisonerJourney.cy.ts
@@ -11,7 +11,7 @@ context('Match By Information Journey', () => {
     cy.task('stubPrisonApiPrisonerImage')
     cy.task('stubPrisonerApiGetPrisonerById', chosenPrisoner.prisonerNumber)
     cy.task('stubLearnerRecordsNoMatchForAll')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'Someone Withaname', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('should render landing page', () => {

--- a/integration_tests/e2e/matchPrisonerJourney.cy.ts
+++ b/integration_tests/e2e/matchPrisonerJourney.cy.ts
@@ -14,7 +14,7 @@ context('Match Prisoner Journey', () => {
     cy.task('stubLearnerRecordsEventsExactMatch')
     cy.task('stubLearnerRecordsLearnersPossibleMatch')
     cy.task('stubLearnerRecordsMatchSuccess')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'Someone Withaname', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('should be able to match a prisoner to a uln', () => {

--- a/integration_tests/e2e/noResultsJourney.cy.ts
+++ b/integration_tests/e2e/noResultsJourney.cy.ts
@@ -12,7 +12,7 @@ context('No Results Journey', () => {
     cy.task('stubPrisonerApiGetPrisonerById', chosenPrisoner.prisonerNumber)
     cy.task('stubLearnerRecordsNoMatchForAll')
     cy.task('stubLearnerRecordsLearnersNoMatches')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'Someone Withaname', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('should be shown page indicating no results when none are found', () => {

--- a/integration_tests/e2e/searchByInformationJourney.cy.ts
+++ b/integration_tests/e2e/searchByInformationJourney.cy.ts
@@ -13,7 +13,7 @@ context('Search By Information Journey', () => {
     cy.task('stubLearnerRecordsNoMatchForAll')
     cy.task('stubLearnerRecordsEventsExactMatch')
     cy.task('stubLearnerRecordsLearnersPossibleMatch')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'Someone Withaname', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('should be able to search for multiple records by information', () => {

--- a/integration_tests/e2e/searchByUlnJourney.cy.ts
+++ b/integration_tests/e2e/searchByUlnJourney.cy.ts
@@ -12,7 +12,7 @@ context('Search By ULN Journey', () => {
     cy.task('stubPrisonerApiGetPrisonerById', chosenPrisoner.prisonerNumber)
     cy.task('stubLearnerRecordsNoMatchForAll')
     cy.task('stubLearnerRecordsEventsExactMatch')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'Someone Withaname', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('should be able to search for an individual record by ULN', () => {

--- a/integration_tests/e2e/signIn.cy.ts
+++ b/integration_tests/e2e/signIn.cy.ts
@@ -5,7 +5,7 @@ import Page from '../pages/page'
 context('Sign In', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'John Smith', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('Unauthenticated user directed to auth', () => {
@@ -49,7 +49,7 @@ context('Sign In', () => {
     Page.verifyOnPage(AuthSignInPage)
 
     cy.task('stubVerifyToken', true)
-    cy.task('stubSignIn', { name: 'bobby brown' })
+    cy.task('stubSignIn', { name: 'bobby brown', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
 
     cy.signIn()
 

--- a/integration_tests/e2e/tooManyResultsJourney.cy.ts
+++ b/integration_tests/e2e/tooManyResultsJourney.cy.ts
@@ -12,7 +12,7 @@ context('Too Many Results Journey', () => {
     cy.task('stubPrisonerApiGetPrisonerById', chosenPrisoner.prisonerNumber)
     cy.task('stubLearnerRecordsNoMatchForAll')
     cy.task('stubLearnerRecordsLearnersTooManyMatches')
-    cy.task('stubSignIn')
+    cy.task('stubSignIn', { name: 'Someone Withaname', roles: ['ROLE_MATCH_LEARNER_RECORD_RW'] })
   })
 
   it('should be shown page indicating there are too many results for the search criteria', () => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -38,7 +38,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpStaticResources())
   nunjucksSetup(app)
   app.use(setUpAuthentication())
-  app.use(authorisationMiddleware())
+  app.use(authorisationMiddleware(['ROLE_MATCH_LEARNER_RECORD_RW']))
   app.use(setUpCsrf())
   app.use(setUpCurrentUser())
   app.use(errorMessageMiddleware)

--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -1,10 +1,12 @@
 {% extends "./partials/layout.njk" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">
-    Authorisation Error
-  </h1>
-  <p>
-    You are not authorised to use this application.
-  </p>
+  <div class="govuk-width-container">
+    <h1 class="govuk-heading-l">
+      Authorisation Error
+    </h1>
+    <p>
+      You are not authorised to use this application.
+    </p>
+  </div>
 {% endblock %}


### PR DESCRIPTION
The authorisation middlewear is already tested, made specifically for this use case.
Adding the role in really is as simple as this.
You can try it locally by changing the role to something random and then logging in, it will show unauthorised.

Unauth page displayed funny, had to put in the govuk width container.