### PR TITLE
Btd 673 prepopulate with personal information

### DIFF
--- a/server/routes/searchForLearnerRecord/searchForLearnerRecordController.test.ts
+++ b/server/routes/searchForLearnerRecord/searchForLearnerRecordController.test.ts
@@ -102,7 +102,11 @@ describe('searchForLearnerRecordController', () => {
         who: req.user.username,
         correlationId: req.id,
       })
-      expect(res.render).toHaveBeenCalledWith('pages/searchForLearnerRecord/byUln', {})
+      expect(res.render).toHaveBeenCalledWith('pages/searchForLearnerRecord/byUln', {
+        form: {
+          uln: undefined,
+        },
+      })
     })
   })
 
@@ -113,7 +117,15 @@ describe('searchForLearnerRecordController', () => {
         who: req.user.username,
         correlationId: req.id,
       })
-      expect(res.render).toHaveBeenCalledWith('pages/searchForLearnerRecord/byInformation', {})
+      expect(res.render).toHaveBeenCalledWith('pages/searchForLearnerRecord/byInformation', {
+        form: {
+          'dob-day': undefined,
+          'dob-month': undefined,
+          'dob-year': undefined,
+          familyName: undefined,
+          givenName: undefined,
+        },
+      })
     })
   })
 

--- a/server/routes/searchForLearnerRecord/searchForLearnerRecordController.test.ts
+++ b/server/routes/searchForLearnerRecord/searchForLearnerRecordController.test.ts
@@ -97,6 +97,7 @@ describe('searchForLearnerRecordController', () => {
 
   describe('getSearchForLearnerRecordViewByUln', () => {
     it('should get search for learner record view by uln page', async () => {
+      req.params.prisonNumber = ''
       await controller.getSearchForLearnerRecordViewByUln(req, res, next)
       expect(auditService.logPageView).toHaveBeenCalledWith(Page.SEARCH_BY_ULN_PAGE, {
         who: req.user.username,
@@ -108,10 +109,43 @@ describe('searchForLearnerRecordController', () => {
         },
       })
     })
+
+    it('should get search for learner record view by uln page - from searchResults', async () => {
+      req.params.prisonNumber = 'A1898EC'
+      req.session.searchResults = {
+        data: [
+          {
+            age: 48,
+            matchedUln: '1026893096',
+            status: 'Matched',
+            imageId: 'placeholder',
+            prisonerNumber: 'A1898EC',
+            firstName: 'Darcie',
+            lastName: 'Tucker',
+            prisonId: 'BXI',
+            prisonName: 'Brixton (HMP)',
+            cellLocation: 'A-1-040',
+            dateOfBirth: '16-08-1976',
+          },
+        ],
+      }
+
+      await controller.getSearchForLearnerRecordViewByUln(req, res, next)
+      expect(auditService.logPageView).toHaveBeenCalledWith(Page.SEARCH_BY_ULN_PAGE, {
+        who: req.user.username,
+        correlationId: req.id,
+      })
+      expect(res.render).toHaveBeenCalledWith('pages/searchForLearnerRecord/byUln', {
+        form: {
+          uln: '1026893096',
+        },
+      })
+    })
   })
 
   describe('getSearchForLearnerRecordViewByInformation', () => {
     it('should get search for learner record view by information page', async () => {
+      req.params.prisonNumber = ''
       await controller.getSearchForLearnerRecordViewByInformation(req, res, next)
       expect(auditService.logPageView).toHaveBeenCalledWith(Page.SEARCH_BY_INFORMATION_PAGE, {
         who: req.user.username,
@@ -124,6 +158,41 @@ describe('searchForLearnerRecordController', () => {
           'dob-year': undefined,
           familyName: undefined,
           givenName: undefined,
+        },
+      })
+    })
+
+    it('should get search for learner record view by information page - from searchResult', async () => {
+      req.params.prisonNumber = 'A1898EC'
+      req.session.searchResults = {
+        data: [
+          {
+            age: 48,
+            matchedUln: '1026893096',
+            status: 'Matched',
+            imageId: 'placeholder',
+            prisonerNumber: 'A1898EC',
+            firstName: 'Darcie',
+            lastName: 'Tucker',
+            prisonId: 'BXI',
+            prisonName: 'Brixton (HMP)',
+            cellLocation: 'A-1-040',
+            dateOfBirth: '16-08-1976',
+          },
+        ],
+      }
+      await controller.getSearchForLearnerRecordViewByInformation(req, res, next)
+      expect(auditService.logPageView).toHaveBeenCalledWith(Page.SEARCH_BY_INFORMATION_PAGE, {
+        who: req.user.username,
+        correlationId: req.id,
+      })
+      expect(res.render).toHaveBeenCalledWith('pages/searchForLearnerRecord/byInformation', {
+        form: {
+          'dob-day': '16',
+          'dob-month': '08',
+          'dob-year': 1976,
+          familyName: 'Tucker',
+          givenName: 'Darcie',
         },
       })
     })

--- a/server/views/pages/searchForLearnerRecord/byInformation.njk
+++ b/server/views/pages/searchForLearnerRecord/byInformation.njk
@@ -94,12 +94,14 @@
           },
           id: "postcode",
           name: "postcode",
+          value: form.postcode,
           classes: "govuk-input--width-10"
         }) }}
 
         {{ govukSelect({
           id: "sex",
           name: "sex",
+          value: form.sex,
           label: {
             text: "Sex (optional)",
             classes: "govuk-!-font-weight-bold"


### PR DESCRIPTION
This PR includes:

- Pre-populate search page with the data stored against the record in Nomis from the Prisoner Search API. Note that the API does not return _Postcode_ nor _Sex_, these optional fields once manually entered in the search box will be 'remembered' after clicking the **back** button.