### PR TITLE
Btd 675 prepopulate perinfo with gender postcode

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,8 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
     MANAGE_USERS_API_URL: 'https://manage-users-api-dev.hmpps.service.justice.gov.uk'
     DPS_HOME_PAGE_URL: "https://digital-dev.prison.service.justice.gov.uk"
+    # Open LRS link
+    OPEN_LRS_LINK: "https://cmp-idp.dev.lrs.education.gov.uk/"
 
 generic-prometheus-alerts:
   alertSeverity: education-alerts-non-prod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -19,6 +19,8 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
     MANAGE_USERS_API_URL: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
     DPS_HOME_PAGE_URL: "https://digital-preprod.prison.service.justice.gov.uk"
+    # Open LRS link
+    OPEN_LRS_LINK: "https://idp.lrs.education.gov.uk/"
 
 generic-prometheus-alerts:
   alertSeverity: education-alerts-non-prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,6 +17,8 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components.hmpps.service.justice.gov.uk"
     MANAGE_USERS_API_URL: "https://manage-users-api.hmpps.service.justice.gov.uk"
     DPS_HOME_PAGE_URL: "https://digital.prison.service.justice.gov.uk"
+    # Open LRS link
+    OPEN_LRS_LINK: "https://idp.lrs.education.gov.uk/"
 
 generic-prometheus-alerts:
   alertSeverity: education-alerts

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -12,6 +12,9 @@ export declare module 'express-session' {
     searchByInformationResults: LearnersResponse
     prisoner: PrisonerSummary
     searchResults: SearchResults
+    data: {
+      [key: string]: unknown
+    }
   }
 }
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -16,6 +16,7 @@ import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpStaticResources from './middleware/setUpStaticResources'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import setUpWebSession from './middleware/setUpWebSession'
+import setUpLocals from './middleware/setUpLocals'
 
 import routes from './routes'
 import type { Services } from './services'
@@ -43,6 +44,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
   app.use(errorMessageMiddleware)
+  app.use(setUpLocals())
 
   app.use(
     dpsComponents.getPageComponents({

--- a/server/config.ts
+++ b/server/config.ts
@@ -146,4 +146,5 @@ export default {
   },
   ingressUrl: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
+  openLrsLink: get('OPEN_LRS_LINK', ''),
 }

--- a/server/data/prisonerSearch/prisonerSearchClient.test.ts
+++ b/server/data/prisonerSearch/prisonerSearchClient.test.ts
@@ -92,6 +92,8 @@ describe('prisonerSearchClient', () => {
         cellLocation: 'LEI-1-2',
         nationality: 'British',
         dateOfBirth: '02-01-1990',
+        gender: undefined,
+        postalCode: '',
       },
     ])
   })

--- a/server/data/prisonerSearch/prisonerSearchResult.ts
+++ b/server/data/prisonerSearch/prisonerSearchResult.ts
@@ -28,4 +28,10 @@ export default class PrisonerSearchResult {
 
   @Expose()
   nationality: string
+
+  @Expose()
+  gender: string
+
+  @Expose()
+  postalCode: string
 }

--- a/server/data/prisonerSearch/prisonerSearchResult.ts
+++ b/server/data/prisonerSearch/prisonerSearchResult.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Expose, Type, Transform } from 'class-transformer'
 
 export default class PrisonerSearchResult {
@@ -32,6 +33,10 @@ export default class PrisonerSearchResult {
   @Expose()
   gender: string
 
+  @Transform(({ obj }) => {
+    const address = obj.addresses?.find((addr: any) => addr.primaryAddress) || obj.addresses?.[0]
+    return address?.postalCode ?? ''
+  })
   @Expose()
   postalCode: string
 }

--- a/server/middleware/setUpLocals.test.ts
+++ b/server/middleware/setUpLocals.test.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import setUpLocals from './setUpLocals'
+import config from '../config'
+
+describe('setUpLocals middleware', () => {
+  it('should set res.locals.openLrsLink from config and call next', () => {
+    const middleware = setUpLocals().stack[0].handle
+
+    // Mock req, res, next
+    const req = {} as any
+    const res = { locals: {} } as any
+    const next = jest.fn()
+
+    // Call the middleware
+    middleware(req, res, next)
+
+    // It sets the config value correctly
+    expect(res.locals.openLrsLink).toBe(config.openLrsLink)
+
+    // It calls next()
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/middleware/setUpLocals.ts
+++ b/server/middleware/setUpLocals.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express'
+import config from '../config'
+
+// Add constants and utilities to locals
+export default function setUpLocals(): Router {
+  const router = Router({ mergeParams: true })
+
+  router.use((req, res, next) => {
+    res.locals.openLrsLink = config.openLrsLink
+    next()
+  })
+
+  return router
+}

--- a/server/routes/prisonerSearch/findAPrisonerController.test.ts
+++ b/server/routes/prisonerSearch/findAPrisonerController.test.ts
@@ -76,6 +76,8 @@ describe('FindPrisonerController', () => {
         cellLocation: '',
         dateOfBirth: undefined,
         nationality: '',
+        gender: '',
+        postalCode: '',
       }
 
       const checkResponse: CheckMatchResponse = {

--- a/server/routes/searchForLearnerRecord/searchForLearnerRecordController.ts
+++ b/server/routes/searchForLearnerRecord/searchForLearnerRecordController.ts
@@ -48,6 +48,8 @@ export default class SearchForLearnerRecordController {
     const form = {
       givenName: prisoner.firstName,
       familyName: prisoner.lastName,
+      sex: prisoner.gender?.toUpperCase(),
+      postcode: prisoner.postalCode,
       'dob-day':
         prisoner.dateOfBirth &&
         parse(prisoner.dateOfBirth, 'dd-MM-yyyy', new Date()).getDate().toString().padStart(2, '0'),

--- a/server/utils/session.test.ts
+++ b/server/utils/session.test.ts
@@ -1,0 +1,35 @@
+import { Request } from 'express'
+import { setSessionData, getSessionData, deleteSessionData } from './session'
+
+describe('session data functions', () => {
+  let req: Request
+
+  beforeEach(() => {
+    req = { session: { data: {} } } as Request
+  })
+
+  it('should set session data', () => {
+    const keys = ['key1', 'key2']
+    const newValue = 'new value'
+    setSessionData(req, keys, newValue)
+    expect(req.session.data[keys.join('_')]).toBe(newValue)
+  })
+
+  it('should get session data', () => {
+    const keys = ['key1', 'key2']
+    const defaultValue = 'default value'
+    const value = 'test value'
+    req.session.data[keys.join('_')] = value
+    expect(getSessionData(req, keys, defaultValue)).toBe(value)
+    expect(getSessionData(req, ['nonexistentkey'], defaultValue)).toBe(defaultValue)
+  })
+
+  it('should delete session data', () => {
+    const keys = ['key1', 'key2']
+    const value = 'test value'
+    req.session.data[keys.join('_')] = value
+    expect(req.session.data[keys.join('_')]).toBe(value)
+    deleteSessionData(req, keys)
+    expect(req.session.data[keys.join('_')]).toBeUndefined()
+  })
+})

--- a/server/utils/session.ts
+++ b/server/utils/session.ts
@@ -1,0 +1,23 @@
+import type { Request } from 'express'
+
+export const setSessionData = (
+  req: Request,
+  keys: string[],
+  newValue: string | boolean | number | object | Record<string, unknown>,
+): void => {
+  req.session.data[keys.join('_')] = newValue
+}
+
+export const getSessionData = (
+  req: Request,
+  keys: string[],
+  defaultValue?: string | boolean | number | object | Record<string, unknown>,
+) => {
+  return req.session.data[keys.join('_')] || defaultValue
+}
+
+export const deleteSessionData = (req: Request, keys: string[]): void => {
+  if (req.session.data[keys.join('_')]) {
+    delete req.session.data[keys.join('_')]
+  }
+}

--- a/server/views/pages/noMatchFound.njk
+++ b/server/views/pages/noMatchFound.njk
@@ -17,7 +17,7 @@
 <p>There are no LRS records matching your search criteria.</p>
 <p>Try adjusting your search criteria, removing optional information like postcode<br>
   and biological sex, or searching by ULN if known.</p>
-  <p>If you still cannot find the record. <a class="govuk-link" href="https://idp.lrs.education.gov.uk/">Open LRS</a> and create a new one for the prisoner.</p>
+  <p>If you still cannot find the record. <a class="govuk-link" href="{{ openLrsLink }}">Open LRS</a> and create a new one for the prisoner.</p>
 </div>
   <div class="govuk-button-group">
     {{ govukButton({

--- a/server/views/pages/searchForLearnerRecord/byInformation.njk
+++ b/server/views/pages/searchForLearnerRecord/byInformation.njk
@@ -109,8 +109,7 @@
           items: [
             {
               value: "",
-              text: "Select their sex",
-              selected: true
+              text: "Select their sex"
             },
             {
               value: "MALE",


### PR DESCRIPTION
This PR adds 2 missing fields to populate the personal information search page:

- gender (sex)
- postcode (postalCode)

Note
An offender record can comprise multiple addresses, this PR only retrieves an address if it's a **primary** address.
