### PR TITLE
BTD-707: set http cache properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1915,9 +1915,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1929,10 +1929,20 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/core": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
-      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1980,13 +1990,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
-      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -2000,27 +2013,14 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
-      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2079,9 +2079,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4830,9 +4830,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -6243,16 +6243,16 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
-      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "compressible": "~2.0.18",
         "debug": "2.6.9",
         "negotiator": "~0.6.4",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
@@ -7362,22 +7362,23 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
-      "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.11.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.20.0",
-        "@eslint/plugin-kit": "^0.2.5",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
+        "@eslint/core": "^0.15.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.31.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -7385,9 +7386,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -7629,9 +7630,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -7658,10 +7659,34 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7684,16 +7709,29 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7703,9 +7741,9 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7924,16 +7962,16 @@
       }
     },
     "node_modules/express-session": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
-      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "0.7.2",
         "cookie-signature": "1.0.7",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "parseurl": "~1.3.3",
         "safe-buffer": "5.2.1",
         "uid-safe": "~2.1.5"
@@ -12351,9 +12389,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"

--- a/server/app.ts
+++ b/server/app.ts
@@ -2,8 +2,8 @@ import express from 'express'
 import 'reflect-metadata'
 
 import createError from 'http-errors'
-
 import dpsComponents from '@ministryofjustice/hmpps-connect-dps-components'
+
 import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'
 import { appInsightsMiddleware } from './utils/azureAppInsights'
@@ -40,7 +40,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpStaticResources())
   nunjucksSetup(app)
   app.use(setUpAuthentication())
-  app.use(authorisationMiddleware(['ROLE_MATCH_LEARNER_RECORD_RW']))
+  app.use(authorisationMiddleware(['MATCH_LEARNER_RECORD_RW']))
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
   app.use(errorMessageMiddleware)

--- a/server/middleware/disableSensitiveCaching.test.ts
+++ b/server/middleware/disableSensitiveCaching.test.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express'
+import noCacheMiddleware from './disableSensitiveCaching'
+
+describe('disableSensitiveCaching middleware', () => {
+  let req: Partial<Request>
+  let res: Partial<Response>
+  let next: jest.Mock
+
+  beforeEach(() => {
+    req = {}
+    res = {
+      setHeader: jest.fn(),
+    }
+    next = jest.fn()
+  })
+
+  it('should set Cache-Control and Pragma headers', () => {
+    noCacheMiddleware(req as Request, res as Response, next as NextFunction)
+
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store')
+    expect(res.setHeader).toHaveBeenCalledWith('Pragma', 'no-cache')
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/middleware/disableSensitiveCaching.ts
+++ b/server/middleware/disableSensitiveCaching.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from 'express'
+
+// Prevent caching for sensitive content
+const disableSensitiveCaching = (req: Request, res: Response, next: NextFunction) => {
+  res.setHeader('Cache-Control', 'no-store')
+  res.setHeader('Pragma', 'no-cache')
+  next()
+}
+
+export default disableSensitiveCaching

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -11,7 +11,17 @@ export default function setUpStaticResources(): Router {
   router.use(compression())
 
   //  Static Resources Configuration
-  const staticResourcesConfig = { maxAge: config.staticResourceCacheDuration, redirect: false }
+  const cacheControl = { maxAge: config.staticResourceCacheDuration, redirect: false }
+
+  // Function to exclude hidden files
+  const excludeHiddenFiles = (res: { setHeader: (arg0: string, arg1: string) => void }, filePath: string) => {
+    if (filePath.split('/').some(part => part.startsWith('.'))) {
+      // Skip hidden files by not setting headers
+      return
+    }
+    // Allow other files
+    res.setHeader('Cache-Control', `max-age=${cacheControl.maxAge}`)
+  }
 
   Array.of(
     '/dist/assets',
@@ -21,11 +31,14 @@ export default function setUpStaticResources(): Router {
     '/node_modules/@ministryofjustice/frontend',
     '/node_modules/jquery/dist',
   ).forEach(dir => {
-    router.use('/assets', express.static(path.join(process.cwd(), dir), staticResourcesConfig))
+    router.use('/assets', express.static(path.join(process.cwd(), dir), { setHeaders: excludeHiddenFiles }))
   })
 
   Array.of('/node_modules/jquery/dist/jquery.min.js').forEach(dir => {
-    router.use('/assets/js/jquery.min.js', express.static(path.join(process.cwd(), dir), staticResourcesConfig))
+    router.use(
+      '/assets/js/jquery.min.js',
+      express.static(path.join(process.cwd(), dir), { setHeaders: excludeHiddenFiles }),
+    )
   })
 
   // Don't cache dynamic resources

--- a/server/routes/alreadyMatched/index.ts
+++ b/server/routes/alreadyMatched/index.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express'
 import AlreadyMatchedController from './alreadyMatchedController'
 import { Services } from '../../services'
+import noCacheMiddleware from '../../middleware/disableSensitiveCaching'
 
 export default function alreadyMatchedRoutes(router: Router, services: Services) {
   const alreadyMatchedController = new AlreadyMatchedController(services.auditService)
-  router.get('/already-matched/:prisonerNumber/:uln', alreadyMatchedController.getAlreadyMatched)
+  router.get('/already-matched/:prisonerNumber/:uln', [noCacheMiddleware, alreadyMatchedController.getAlreadyMatched])
 }

--- a/server/routes/imageApi/index.ts
+++ b/server/routes/imageApi/index.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import ImageApiController from './imageApiController'
+import noCacheMiddleware from '../../middleware/disableSensitiveCaching'
 
 export default function findAPrisonerRoutes(router: Router, services: Services) {
   const apiController = new ImageApiController(services.auditService, services.prisonApiService)
-  router.get('/api/image/:imageId', apiController.prisonerImage)
+  router.get('/api/image/:imageId', [noCacheMiddleware, apiController.prisonerImage])
 }

--- a/server/routes/learnerSearchResults/index.ts
+++ b/server/routes/learnerSearchResults/index.ts
@@ -2,11 +2,13 @@ import { Router } from 'express'
 import LearnerSearchResultsController from './learnerSearchResultsController'
 import retrievePrisonerSummary from '../routerRequestHandlers/retrievePrisonerSummary'
 import { Services } from '../../services'
+import noCacheMiddleware from '../../middleware/disableSensitiveCaching'
 
 export default (router: Router, services: Services) => {
   const searchForLearnerRecordController = new LearnerSearchResultsController(services.auditService)
 
   router.get('/learner-search-results/:prisonNumber', [
+    noCacheMiddleware,
     retrievePrisonerSummary(services.prisonerSearchService),
     searchForLearnerRecordController.getLearnerSearchResults,
   ])

--- a/server/routes/matchConfirmed/index.ts
+++ b/server/routes/matchConfirmed/index.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express'
 import MatchConfirmedController from './matchConfirmedController'
 import { Services } from '../../services'
+import noCacheMiddleware from '../../middleware/disableSensitiveCaching'
 
 export default function matchConfirmedRoutes(router: Router, services: Services) {
   const matchConfirmedController = new MatchConfirmedController(services.auditService)
-  router.get('/match-confirmed/:prisonerNumber/:uln', matchConfirmedController.getMatchConfirmed)
+  router.get('/match-confirmed/:prisonerNumber/:uln', [noCacheMiddleware, matchConfirmedController.getMatchConfirmed])
 }

--- a/server/routes/prisonerSearch/index.ts
+++ b/server/routes/prisonerSearch/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import FindAPrisonerController from './findAPrisonerController'
+import noCacheMiddleware from '../../middleware/disableSensitiveCaching'
 
 export default function findAPrisonerRoutes(router: Router, services: Services) {
   const findAPrisonerController = new FindAPrisonerController(
@@ -9,7 +10,7 @@ export default function findAPrisonerRoutes(router: Router, services: Services) 
     services.prisonApiService,
     services.learnerRecordsService,
   )
-  router.get('/find-a-prisoner', findAPrisonerController.getFindAPrisoner)
+  router.get('/find-a-prisoner', [noCacheMiddleware, findAPrisonerController.getFindAPrisoner])
   router.post('/find-a-prisoner', findAPrisonerController.postFindAPrisoner)
-  router.get('/find-a-prisoner-clear', findAPrisonerController.clearResultsAndRedirect)
+  router.get('/find-a-prisoner-clear', [noCacheMiddleware, findAPrisonerController.clearResultsAndRedirect])
 }

--- a/server/routes/searchForLearnerRecord/index.ts
+++ b/server/routes/searchForLearnerRecord/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import { Services } from '../../services'
 import SearchForLearnerRecordController from './searchForLearnerRecordController'
 import retrievePrisonerSummary from '../routerRequestHandlers/retrievePrisonerSummary'
+import noCacheMiddleware from '../../middleware/disableSensitiveCaching'
 
 export default (router: Router, services: Services) => {
   const searchForLearnerRecordController = new SearchForLearnerRecordController(
@@ -11,10 +12,12 @@ export default (router: Router, services: Services) => {
   )
 
   router.get('/search-for-learner-record-by-uln/:prisonNumber', [
+    noCacheMiddleware,
     retrievePrisonerSummary(services.prisonerSearchService),
     searchForLearnerRecordController.getSearchForLearnerRecordViewByUln,
   ])
   router.get('/search-for-learner-record-by-information/:prisonNumber', [
+    noCacheMiddleware,
     retrievePrisonerSummary(services.prisonerSearchService),
     searchForLearnerRecordController.getSearchForLearnerRecordViewByInformation,
   ])

--- a/server/routes/tooManyResults/index.ts
+++ b/server/routes/tooManyResults/index.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express'
 import TooManyResultsController from './tooManyResultsController'
+import noCacheMiddleware from '../../middleware/disableSensitiveCaching'
 
 export default function tooManyResultsRoutes(router: Router) {
   const tooManyResultsController = new TooManyResultsController()
-  router.get('/too-many-results/:prisonerNumber', tooManyResultsController.getTooManyResults)
+  router.get('/too-many-results/:prisonerNumber', [noCacheMiddleware, tooManyResultsController.getTooManyResults])
 }

--- a/server/routes/viewRecord/index.ts
+++ b/server/routes/viewRecord/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import ViewRecordController from './viewRecordController'
 import { Services } from '../../services'
 import retrievePrisonerSummary from '../routerRequestHandlers/retrievePrisonerSummary'
+import noCacheMiddleware from '../../middleware/disableSensitiveCaching'
 
 export default function viewRecordRoutes(router: Router, services: Services) {
   const viewRecordController = new ViewRecordController(
@@ -10,10 +11,12 @@ export default function viewRecordRoutes(router: Router, services: Services) {
     services.auditService,
   )
   router.get('/view-record/:prisonNumber/:uln', [
+    noCacheMiddleware,
     retrievePrisonerSummary(services.prisonerSearchService),
     viewRecordController.getViewRecord,
   ])
   router.get('/view-matched-record/:prisonNumber/:uln', [
+    noCacheMiddleware,
     retrievePrisonerSummary(services.prisonerSearchService),
     viewRecordController.getViewMatchedRecord,
   ])


### PR DESCRIPTION
This PR implements recommendations of the last [AppSec report](https://justiceuk-my.sharepoint.com/shared?listurl=https%3A%2F%2Fjusticeuk%2Esharepoint%2Ecom%2Fsites%2FAppsecProgramme290%2FShared%20Documents&id=%2Fsites%2FAppsecProgramme290%2FShared%20Documents%2FGeneral%2FService%20Assessments%20%28Appsec%20Tests%20%26%20ITHCs%29%2FHMPPS%20Data%20Engineering%20Learner%20Record%20App%2FConfiguration%20Review%20Results%2FDAST%2Fui%2Dreport%2Ehtml&parent=%2Fsites%2FAppsecProgramme290%2FShared%20Documents%2FGeneral%2FService%20Assessments%20%28Appsec%20Tests%20%26%20ITHCs%29%2FHMPPS%20Data%20Engineering%20Learner%20Record%20App%2FConfiguration%20Review%20Results%2FDAST)

The web server should return the following HTTP headers in all responses containing sensitive content:

- Cache-control: no-store
- Pragma: no-cache